### PR TITLE
Add weak self in proper places of W3WMapViewController to fix memory leaks

### DIFF
--- a/Sources/W3WSwiftComponents/Map/W3WMapViewController.swift
+++ b/Sources/W3WSwiftComponents/Map/W3WMapViewController.swift
@@ -59,13 +59,13 @@ open class W3WMapViewController: UIViewController, UIGestureRecognizerDelegate, 
     w3wMapView.delegate = mapHelper
     
     // if a marker was tapped
-    mapHelper?.onMarkerSelected = { square in
-      self.onMarkerSelected(square)
+    mapHelper?.onMarkerSelected = { [weak self] square in
+      self?.onMarkerSelected(square)
     }
     
     // forward any map helper errors to the owner of this object
-    mapHelper?.onError = { error in
-      self.onError(error)
+    mapHelper?.onError = { [weak self] error in
+      self?.onError(error)
     }
   }
 


### PR DESCRIPTION
MapHelper is a strong property of `W3WMapViewController`.

Two closures of MapHelper (`onMarkerSelected` and `onError`) capture `self` strongly that causes a retain cycle. So if the method  `public func set(_ w3w: W3WProtocolV3, language: String = W3WSettings.defaultLanguage)` is called then `W3WMapViewController` is never deallocated.

I use a custom child class of `W3WMapViewController` in my code and need to call the mentioned method so my child class is never deallocated and it causes memory leaks in my project. That's why I propose these fixes.

The proposed PR passes self as a weak instance that causes memory leak issues in the method `public func set(_ w3w: W3WProtocolV3, language: String = W3WSettings.defaultLanguage)` of `W3WMapViewController`. 

Please merge this PR and prepare the next release of W3W-Swift-Components.

